### PR TITLE
Specify charset as UTF-8

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-
+        <meta charset="utf-8" /> 
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
         <link rel="stylesheet" type="text/css" href="vendours/css/normalize.css">


### PR DESCRIPTION
![image1PNG](https://user-images.githubusercontent.com/22260722/97110416-27677680-16d1-11eb-9e97-76f88d4f93ba.PNG)
Stops this error from happening. When I went on the page some of the text was garbled and this PR fixes the text as seen below..
![image2PNG](https://user-images.githubusercontent.com/22260722/97110460-5e3d8c80-16d1-11eb-8a3a-456c95d5fde9.PNG)

